### PR TITLE
/maternity-paternity-calculator start page text change

### DIFF
--- a/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
+++ b/lib/smart_answer_flows/maternity-paternity-calculator/maternity_paternity_calculator.govspeak.erb
@@ -30,4 +30,5 @@
   + births 15 weeks before the due date
   + paternity leave or pay for [overseas adoptions](/employers-paternity-pay-leave/adoption)
   + [Shared Parental Leave and Pay](/shared-parental-leave-and-pay-employer-guide)
+  + [mistimed payments](/guidance/statutory-maternity-pay-manually-calculate-your-employees-payments#mistimed-payments) (when you pay someone earlier or later than their normal payday, for example after a bank holiday)
 <% end %>


### PR DESCRIPTION
Added new bullet to end of /maternity-paternity-calculator start page to clarify that you can't use the calculator for mistimed payments. Content request: https://govuk.zendesk.com/agent/tickets/1361444
